### PR TITLE
Update matchit to fix empty routes issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,10 @@ repository = "https://github.com/balena-io-modules/mahler-rs"
 anyhow = "1.0.97"
 json-patch = "4"
 jsonptr = "0.7.1"
-matchit = "0.8.4"
+# FIXME: this is using the revision for https://github.com/ibraheemdev/matchit/pull/76 
+# revert to using the version once a new release of matchit is available (latest version at 
+# the time of this commit was 0.8.6)
+matchit = { git = "https://github.com/ibraheemdev/matchit.git", rev = "8fef456b044ec84532dea99f1857177b90d416e0" }
 serde = "1.0.197"
 serde_json = "1.0.120"
 thiserror = "2"

--- a/src/planner/domain.rs
+++ b/src/planner/domain.rs
@@ -324,4 +324,19 @@ mod tests {
         let result = domain.find_path_for_job(func.id(), &mut args);
         assert!(result.is_err());
     }
+
+    // See: https://github.com/ibraheemdev/matchit/issues/75
+    #[test]
+    fn test_finds_jobs_for_empty_paths() {
+        let func = |view: View<()>| view;
+        let domain = Domain::new()
+            .job("", update(func))
+            .job("/other", update(plus_two));
+
+        if let Some((_, mut jobs)) = domain.find_matching_jobs("") {
+            assert!(jobs.any(|j| j.id() == func.id()));
+        } else {
+            panic!("should find a job")
+        }
+    }
 }

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -339,6 +339,7 @@ impl Planner {
                 let path = Path::new(op.path());
 
                 // Retrieve matching jobs at this path
+                trace!("finding jobs for path '{path}'");
                 if let Some((args, jobs)) = self.0.find_matching_jobs(path.as_str()) {
                     let pointer = path.as_ref();
                     let target = pointer.resolve(tgt).unwrap_or(&Value::Null);


### PR DESCRIPTION
Inconsistent behavior would happen when inserting an empty route first in the domain. This was traced to the matchit dependency and fixed on https://github.com/ibraheemdev/matchit/pull/76, this update that dependency to that revision

Change-type: patch