### PR TITLE
Fix missing matchit version for cargo publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ anyhow = "1.0.97"
 json-patch = "4"
 jsonptr = "0.7.1"
 # FIXME: this is using the revision for https://github.com/ibraheemdev/matchit/pull/76 
-# revert to using the version once a new release of matchit is available (latest version at 
-# the time of this commit was 0.8.6)
-matchit = { git = "https://github.com/ibraheemdev/matchit.git", rev = "8fef456b044ec84532dea99f1857177b90d416e0" }
+# revert to using only version once a new release (>0.8.6) of matchit is available
+matchit = { version = "0.8.6", git = "https://github.com/ibraheemdev/matchit.git", rev = "8fef456b044ec84532dea99f1857177b90d416e0" }
 serde = "1.0.197"
 serde_json = "1.0.120"
 thiserror = "2"


### PR DESCRIPTION
See: https://github.com/balena-io-modules/mahler-rs/actions/runs/16677452649/job/47207588810

Change-type: patch