### PR TITLE
Escape URI components in route parameters

### DIFF
--- a/examples/composer/src/lib.rs
+++ b/examples/composer/src/lib.rs
@@ -1026,7 +1026,7 @@ mod tests {
             "name": "my-project",
             "services": {
                 "my-service": {
-                    "image": "alpine:3.18",
+                    "image": "docker.io/library/alpine:3.18",
                     "cmd": ["sleep", "infinity"]
                 }
             }
@@ -1040,11 +1040,21 @@ mod tests {
 
         // The alpine image must exist now
         let docker = Docker::connect_with_defaults().unwrap();
-        let img = docker.inspect_image("alpine:3.18").await.unwrap();
+        let img = docker
+            .inspect_image("docker.io/library/alpine:3.18")
+            .await
+            .unwrap();
 
         // The image ids should match
         let state = worker.state().await.unwrap();
-        assert_eq!(state.images.get("alpine:3.18").unwrap().id, img.id);
+        assert_eq!(
+            state
+                .images
+                .get("docker.io/library/alpine:3.18")
+                .unwrap()
+                .id,
+            img.id
+        );
 
         let container = docker
             .inspect_container(&format!("{PROJECT_NAME}_my-service"), None)
@@ -1061,7 +1071,7 @@ mod tests {
             "name": "my-project",
             "services": {
                 "my-service": {
-                    "image": "alpine:3.18",
+                    "image": "docker.io/library/alpine:3.18",
                     "cmd": ["sleep", "infinity"],
                     "status": "Running"
                 }
@@ -1089,7 +1099,7 @@ mod tests {
             "name": "my-project",
             "services": {
                 "my-service": {
-                    "image": "alpine:3.18",
+                    "image": "docker.io/library/alpine:3.18",
                     "cmd": ["sleep", "infinity"],
                     "status": "Stopped"
                 }
@@ -1132,7 +1142,7 @@ mod tests {
         ));
 
         // The image should no longer exist
-        let image = docker.inspect_image("alpine:3.18").await;
+        let image = docker.inspect_image("docker.io/library/alpine:3.18").await;
         assert!(matches!(
             image,
             Err(bollard::errors::Error::DockerResponseServerError { .. })

--- a/src/extract/args/mod.rs
+++ b/src/extract/args/mod.rs
@@ -48,8 +48,8 @@ impl<T: DeserializeOwned + Send> FromContext for Args<T> {
     type Error = ExtractionError;
 
     fn from_context(context: &Context) -> Result<Self, Self::Error> {
-        let args = &context.args;
-        let value = T::deserialize(de::PathDeserializer::new(args)).with_context(|| {
+        let args = context.decoded_args();
+        let value = T::deserialize(de::PathDeserializer::new(&args)).with_context(|| {
             format!(
                 "Failed to deserialize {args} into {}",
                 std::any::type_name::<T>()

--- a/src/path.rs
+++ b/src/path.rs
@@ -104,7 +104,7 @@ impl Deref for Path {
 // Structure to store path arguments when matching
 // against a lens
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
-pub(crate) struct PathArgs(pub Vec<(Arc<str>, String)>);
+pub(crate) struct PathArgs(Vec<(Arc<str>, String)>);
 
 impl PathArgs {
     pub fn iter(&self) -> impl Iterator<Item = &(Arc<str>, String)> {
@@ -159,6 +159,16 @@ impl From<matchit::Params<'_, '_>> for PathArgs {
             .collect();
 
         PathArgs(params)
+    }
+}
+
+impl<K: AsRef<str>, V: Into<String>> From<Vec<(K, V)>> for PathArgs {
+    fn from(args: Vec<(K, V)>) -> Self {
+        PathArgs(
+            args.into_iter()
+                .map(|(k, v)| (Arc::from(k.as_ref()), v.into()))
+                .collect(),
+        )
     }
 }
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -34,7 +34,7 @@ enum SearchFailed {
     #[error("task error: {0:?}")]
     BadTask(#[from] task::Error),
 
-    #[error("task empty")]
+    #[error("task not applicable")]
     EmptyTask,
 
     #[error("loop detected")]
@@ -221,7 +221,7 @@ impl Planner {
                     // The subtask is not allowed to override arguments
                     // in the parent task, so we first make sure to propagate
                     // arguments from the parent
-                    for (k, v) in method.context().args.iter() {
+                    for (k, v) in method.context().decoded_args().iter() {
                         t = t.with_arg(k, v);
                     }
 
@@ -353,6 +353,7 @@ impl Planner {
                     // Filter `None` jobs from the list
                     for job in jobs.filter(|j| j.operation() != &Operation::None) {
                         if op.matches(job.operation()) || job.operation() == &Operation::Any {
+                            trace!("found job for operation: {op}");
                             let task = job.new_task(context.clone());
                             let mut changes = Vec::new();
 


### PR DESCRIPTION
Route parameters can contain characters that need to be URI-encoded when used in JSON pointers. This change ensures proper escaping of route arguments by using jsonptr::Token encoding/decoding.

Change-type: patch